### PR TITLE
Version bumped Babel dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/richard-lopes/webpack-example#readme",
   "dependencies": {
     "alt": "0.17.1",
-    "babel-runtime": "5.6.18",
+    "babel-runtime": "6.2.0",
     "jquery": "2.1.1",
     "pushstate-server": "^1.6.0",
     "react": "0.13.3",
@@ -36,8 +36,8 @@
     "xhr2": "^0.1.3"
   },
   "devDependencies": {
-    "babel-core": "5.6.18",
-    "babel-loader": "5.3.1",
+    "babel-core": "6.2.0",
+    "babel-loader": "6.1.0",
     "css-loader": "^0.16.0",
     "file-loader": "^0.8.4",
     "html-webpack-plugin": "1.6.0",


### PR DESCRIPTION
Npm install command gave an error that babel 5x was deprecated. So I bumped the version up to 6x. 
I tested the project and it works with the latest babel version.